### PR TITLE
Fix Vercel deployment 404 error

### DIFF
--- a/EcoHubVerse_Complete/frontend/package.json
+++ b/EcoHubVerse_Complete/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/EcoHubVerse_Complete/frontend/public/index.html
+++ b/EcoHubVerse_Complete/frontend/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Web site created using create-react-app"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/EcoHubVerse_Complete/frontend/src/App.js
+++ b/EcoHubVerse_Complete/frontend/src/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Dashboard from './modules/Dashboard.jsx';
+
+function App() {
+  return (
+    <div className="App">
+      <Dashboard />
+    </div>
+  );
+}
+
+export default App;

--- a/EcoHubVerse_Complete/frontend/src/index.js
+++ b/EcoHubVerse_Complete/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/EcoHubVerse_Complete/vercel.json
+++ b/EcoHubVerse_Complete/vercel.json
@@ -19,8 +19,24 @@
       "dest": "backend/server.mjs"
     },
     {
+      "src": "/static/(.*)",
+      "dest": "/frontend/build/static/$1"
+    },
+    {
+      "src": "/logo192.png",
+      "dest": "/frontend/build/logo192.png"
+    },
+    {
+      "src": "/manifest.json",
+      "dest": "/frontend/build/manifest.json"
+    },
+    {
+      "src": "/favicon.ico",
+      "dest": "/frontend/build/favicon.ico"
+    },
+    {
       "src": "/(.*)",
-      "dest": "frontend/$1"
+      "dest": "/frontend/build/index.html"
     }
   ]
 }


### PR DESCRIPTION
The Vercel deployment was failing with a 404 error. This was caused by two issues:
1. The frontend project was incomplete. It was missing the `package.json`, `public/index.html`, and the main React entry point files (`src/index.js`, `src/App.js`). This caused the build on Vercel to fail.
2. The `vercel.json` configuration was incorrect for a monorepo with a Create React App frontend. The routing rules were not set up to handle a single-page application.

This commit fixes these issues by:
- Adding the missing `package.json` to the `frontend` directory with the necessary dependencies and build scripts.
- Adding a standard `public/index.html` file.
- Adding `src/index.js` and `src/App.js` to create a valid entry point for the React application. `App.js` is configured to render the existing `Dashboard.jsx` component.
- Updating `vercel.json` with the correct build configuration and routing rules to properly serve the frontend application and handle client-side routing.